### PR TITLE
Refresh Kotlin client dependency and verify quickstart

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")
     implementation("io.ktor:ktor-serialization-jackson:$ktor_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")
-    implementation("com.couchbase.client:kotlin-client:1.5.0")
+    implementation("com.couchbase.client:kotlin-client:3.10.1")
     implementation("io.insert-koin:koin-ktor:$koin_version")
     implementation("io.insert-koin:koin-logger-slf4j:$koin_version")
     implementation("io.github.config4k:config4k:0.7.0")


### PR DESCRIPTION
## Summary
- bump `com.couchbase.client:kotlin-client` from `1.5.0` to `3.10.1`
- reuse the already-validated minimal dependency change from the current verified candidate branch

## Verification
- `./gradlew test --no-daemon`
- earlier candidate walkthrough/evidence under `tutorial-maintenance/runs/kotlin-quickstart/2026-05-05T0145Z-subagent/`

## Evidence
- `tutorial-maintenance/runs/kotlin-quickstart/2026-05-05T0300Z-followup/verification.md`
- `tutorial-maintenance/runs/kotlin-quickstart/2026-05-05T0300Z-followup/test.log`
- `tutorial-maintenance/runs/kotlin-quickstart/2026-05-05T0145Z-subagent/build-and-test.log`
- `tutorial-maintenance/runs/kotlin-quickstart/2026-05-05T0145Z-subagent/sdk-3.10.1-build-and-test.log`
- `tutorial-maintenance/runs/kotlin-quickstart/2026-05-05T0145Z-subagent/walkthrough.log`

## Notes
- No qualifying Dex PR coverage existed for this repo when this follow-up started.
